### PR TITLE
chore: Improve path aliases

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -15,8 +15,8 @@ module.exports = {
         root: ['./'],
         extensions: ['.ts', '.tsx', '.svg', '.json'],
         alias: {
-          // This needs to be mirrored in tsconfig.json
-          [rootPkg.name]: path.join(rootDir, rootPkg['react-native'])
+          // This needs to be mirrored in ./tsconfig.json
+          '@lib': path.join(rootDir, rootPkg['react-native'])
         }
       }
     ]

--- a/example/app/__tests__/App.test.tsx
+++ b/example/app/__tests__/App.test.tsx
@@ -1,5 +1,5 @@
-import { App } from 'example-app';
 import { render } from '@testing-library/react-native';
+import App from '../src/App';
 
 describe(App, () => {
   it('renders', () => {

--- a/example/app/src/App.tsx
+++ b/example/app/src/App.tsx
@@ -1,5 +1,5 @@
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
-import { Greeting } from 'react-native-library-template';
+import { Greeting } from '@lib';
 import { StyleSheet } from 'react-native';
 
 export default function App() {

--- a/example/app/tsconfig.json
+++ b/example/app/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "react-native-library-template": ["../../src"]
+      "@lib": ["../../src"],
+      "@app": ["./src"]
     }
   }
 }

--- a/example/bare/babel.config.js
+++ b/example/bare/babel.config.js
@@ -16,9 +16,10 @@ module.exports = function (api) {
         {
           root: ['./'],
           extensions: ['.ts', '.tsx', '.svg', '.json'],
+          // This needs to be mirrored in ../app/tsconfig.json
           alias: {
-            [rootPkg.name]: path.join(rootDir, rootPkg['react-native']),
-            [appPkg.name]: path.join(appDir, appPkg['react-native'])
+            '@lib': path.join(rootDir, rootPkg['react-native']),
+            '@app': path.join(appDir, appPkg['react-native'])
           }
         }
       ]

--- a/example/bare/index.js
+++ b/example/bare/index.js
@@ -1,6 +1,6 @@
 import { AppRegistry } from 'react-native';
 import { name as appName } from './app.json';
 
-import { App } from 'example-app';
+import { App } from '@app';
 
 AppRegistry.registerComponent(appName, () => App);

--- a/example/expo/babel.config.js
+++ b/example/expo/babel.config.js
@@ -16,9 +16,10 @@ module.exports = function (api) {
         {
           root: ['./'],
           extensions: ['.ts', '.tsx', '.svg', '.json'],
+          // This needs to be mirrored in ../app/tsconfig.json
           alias: {
-            [rootPkg.name]: path.join(rootDir, rootPkg['react-native']),
-            [appPkg.name]: path.join(appDir, appPkg['react-native'])
+            '@lib': path.join(rootDir, rootPkg['react-native']),
+            '@app': path.join(appDir, appPkg['react-native'])
           }
         }
       ]

--- a/example/expo/index.js
+++ b/example/expo/index.js
@@ -1,5 +1,5 @@
 import { registerRootComponent } from 'expo';
 
-import { App } from 'example-app';
+import { App } from '@app';
 
 registerRootComponent(App);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "types": ["node", "jest"],
     "baseUrl": ".",
     "paths": {
-      "react-native-library-template": ["src"]
+      "@lib": ["src"],
+      "@app": ["example/app/src/"]
     }
   },
   "include": ["src", "jest.config.ts", "__tests__"],


### PR DESCRIPTION
## Description

This PR changes path used internally in the library sources and example files to reduce the hassle with path aliases configuration. Paths are now independent on the library name that will appear only in a single place, the root `package.json` file.