### PR TITLE
fix: Add missing dependency in the released library

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "bin": "./bin/index.js",
   "bugs": "https://github.com/MatiPl01/react-native-library-template/issues",
   "dependencies": {
-    "degit": "^2.8.4"
+    "degit": "^2.8.4",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
@@ -22,8 +23,7 @@
     "lint-staged": "^15.2.0",
     "prettier": "^3.1.1",
     "semantic-release": "^22.0.12",
-    "syncpack": "^12.3.0",
-    "yargs": "^17.7.2"
+    "syncpack": "^12.3.0"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
## Description

Moves `yargs` dependency from `devDependencies` to `dependencies` that fixes the missing dep issue.