### PR TITLE
fix: Move chalk dep to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": "./bin/index.js",
   "bugs": "https://github.com/MatiPl01/react-native-library-template/issues",
   "dependencies": {
+    "chalk": "^5.3.0",
     "degit": "^2.8.4",
     "yargs": "^17.7.2"
   },
@@ -16,7 +17,6 @@
     "@semantic-release/github": "^9.2.6",
     "@semantic-release/npm": "^11.0.2",
     "@semantic-release/release-notes-generator": "^12.1.0",
-    "chalk": "^5.3.0",
     "eslint": "^8.56.0",
     "eslint-plugin-prettier": "^5.1.2",
     "husky": "^8.0.3",


### PR DESCRIPTION
## Description

This PR moves another dependency to `dependencies` from `devDependencies`. There shouldn't be more missing deps.